### PR TITLE
 Fixes to flash messages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,14 +13,3 @@
  *= require_tree .
  *= require_self
  */
-.alert {
-padding: 8px 35px 8px 14px;
-margin-bottom: 18px;
-color: #c09853;
-text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
-background-color: #fcf8e3;
-border: 1px solid #fbeed5;
--webkit-border-radius: 4px;
--moz-border-radius: 4px;
-border-radius: 4px;
-}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  
+
   def new
   end
 
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
       log_in user
       redirect_to user
     else
-      flash.now[:error] = 'Invalid email and/or password combination'
+      flash.now[:danger] = 'Invalid email and/or password combination'
       render 'new'
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= render 'layouts/header' %>
     <div class="container">
       <% flash.each do |message_type, message| %>
-        <div class="alert alert-<%= message_type %>"><%= message %></div>
+        <div class="alert alert-<%= message_type %>"><a href='#' class='close' onClick="parentNode.remove()">×</a><%= message %></div>
         <br/>
       <% end %>
       <%= yield %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -2,6 +2,7 @@
   <div id="error_explanation">
     <div class="alert alert-danger">
       The form contains <%= pluralize(@user.errors.count, "error") %>.
+      <a href='#' class='close' onClick="parentNode.remove()">×</a>
     </div>
     <ul>
     <% @user.errors.full_messages.each do |msg| %>

--- a/spec/requests/authentication_pages_spec.rb
+++ b/spec/requests/authentication_pages_spec.rb
@@ -18,11 +18,11 @@ describe "Authentication" do
       before { click_button "Log in" }
 
       it { should have_title('Log in') }
-      it { should have_selector('div.alert.alert-error') }
+      it { should have_selector('div.alert.alert-danger') }
 
       describe "after visiting another page" do
         before { click_link "Home" }
-        it { should_not have_selector('div.alert.alert-error') }
+        it { should_not have_selector('div.alert.alert-danger') }
       end
     end
 


### PR DESCRIPTION
1. Fixes an issue around the error styling wrt login page
2. Ensures that we use bootstrap themed green and red colored style classes to denote success and failure respectively based on a user request.
3. Adds the ability to close a flash message.
