### PR TITLE
Add expense related operations specs and misc changes

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,11 +20,13 @@ RSpec.describe User, type: :model do
 
   describe "when name is not present" do
     before { @user.name = " " }
+
     it { should_not be_valid }
   end
 
   describe "when name is too long" do
     before { @user.name = "a" * 51 }
+
     it { should_not be_valid }
   end
 
@@ -38,6 +40,7 @@ RSpec.describe User, type: :model do
     it "should be invalid" do
       addresses = %w[user@foo,com user_at_foo.org example.user@foo.
                      foo@bar_baz.com foo@bar+baz.com]
+
       addresses.each do |invalid_address|
         @user.email = invalid_address
         expect(@user).not_to be_valid
@@ -48,6 +51,7 @@ RSpec.describe User, type: :model do
   describe "when email format is valid" do
     it "should be valid" do
       addresses = %w[user@foo.COM A_US-ER@f.b.org frst.lst@foo.jp a+b@baz.cn]
+
       addresses.each do |valid_address|
         @user.email = valid_address
         expect(@user).to be_valid
@@ -67,6 +71,7 @@ RSpec.describe User, type: :model do
 
     it "does not allow another user with the same uppercased email from being saved" do
       @user_with_same_email.email = @user.email.upcase
+
       expect(@user_with_same_email).not_to be_valid
     end
   end
@@ -86,6 +91,7 @@ RSpec.describe User, type: :model do
     context "password is nil" do
       it "should not be valid" do
         @user.password_confirmation = nil
+
         expect(@user).not_to be_valid
       end
     end
@@ -93,6 +99,7 @@ RSpec.describe User, type: :model do
     context "password doesn't match confirmation" do
       it "should not be valid" do
         @user.password_confirmation = "mismatch"
+
         expect(@user).not_to be_valid
       end
     end
@@ -101,6 +108,7 @@ RSpec.describe User, type: :model do
       it "should not be valid" do
         @user.password = "a" * 5
         @user.password_confirmation = "a" * 5
+
         expect(@user).not_to be_valid
       end
     end
@@ -138,6 +146,7 @@ RSpec.describe User, type: :model do
 
     it "should destroy associated expenses" do
       user_expenses_count = @user.expenses.count
+
       expect { @user.destroy }.to change { Expense.count }.by(-user_expenses_count)
     end
   end

--- a/spec/requests/authentication_pages_spec.rb
+++ b/spec/requests/authentication_pages_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "Authentication" do
 

--- a/spec/requests/authentication_pages_spec.rb
+++ b/spec/requests/authentication_pages_spec.rb
@@ -37,6 +37,36 @@ describe "Authentication" do
       it { should have_link('Log out',    href: logout_path) }
       it { should_not have_link('Log in', href: login_path) }
     end
-
   end
+
+  describe "authorization" do
+
+    describe "for non-signed-in users" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      describe "in the Expenses controller" do
+
+        describe "submitting to the create action" do
+          before { post expenses_path }
+          specify { expect(response).to redirect_to(login_path) }
+        end
+
+        describe "submitting to the edit action" do
+          before { get edit_expense_path(FactoryGirl.create(:expense, user: user)) }
+          specify { expect(response).to redirect_to(login_path) }
+        end
+
+        describe "submitting to the update action" do
+          before { patch expense_path(FactoryGirl.create(:expense, user: user)) }
+          specify { expect(response).to redirect_to(login_path) }
+        end
+
+        describe "submitting to the destroy action" do
+          before { delete expense_path(FactoryGirl.create(:expense, user: user)) }
+          specify { expect(response).to redirect_to(login_path) }
+        end
+      end
+    end
+  end
+
 end

--- a/spec/requests/expense_pages_spec.rb
+++ b/spec/requests/expense_pages_spec.rb
@@ -21,16 +21,16 @@ describe "Expense pages", type: :request do
 
         describe "error messages" do
           before { click_button "Create expense" }
-          it { should have_content('error') }
+          it { should have_content("error") }
         end
       end
 
       describe "with valid information" do
 
         before do
-          fill_in 'expense_name', with: "Sunglasses"
-          fill_in 'expense_cost', with: "1000"
-          fill_in 'expense_date', with: Time.zone.today
+          fill_in "expense_name", with: "Sunglasses"
+          fill_in "expense_cost", with: "1000"
+          fill_in "expense_date", with: Time.zone.today
         end
         it "should create a expense" do
           expect { click_button "Create expense" }.to change(Expense, :count).by(1)
@@ -45,7 +45,7 @@ describe "Expense pages", type: :request do
         click_link "Create a new expense"
       end
 
-      it { expect(page).to have_selector(:link_or_button, 'Create expense') }
+      it { expect(page).to have_selector(:link_or_button, "Create expense") }
     end
   end
 
@@ -61,7 +61,7 @@ describe "Expense pages", type: :request do
       describe "error messages" do
         context "name is empty" do
           before do
-            fill_in 'expense_name', with: ""
+            fill_in "expense_name", with: ""
             click_button "Update expense"
           end
 
@@ -72,21 +72,21 @@ describe "Expense pages", type: :request do
     end
 
     describe "with valid information" do
-        let(:new_expense_cost)  { 15 }
-        let(:new_expense_name)  { "Coffee" }
-        before do
-          fill_in 'expense_cost', with: new_expense_cost
-          fill_in 'expense_name', with: new_expense_name
-          click_button "Update expense"
-        end
+      let(:new_expense_cost)  { 15 }
+      let(:new_expense_name)  { "Coffee" }
+      before do
+        fill_in "expense_cost", with: new_expense_cost
+        fill_in "expense_name", with: new_expense_name
+        click_button "Update expense"
+      end
 
-        it { should have_content("Expense updated") }
-        it "should update the expense with the correct cost" do
-          expect(expense.reload.cost).to  eq new_expense_cost
-        end
-        it "should update the expense with the correct name" do
-          expect(expense.reload.name).to  eq new_expense_name
-        end
+      it { should have_content("Expense updated") }
+      it "should update the expense with the correct cost" do
+        expect(expense.reload.cost).to eq new_expense_cost
+      end
+      it "should update the expense with the correct name" do
+        expect(expense.reload.name).to eq new_expense_name
+      end
     end
   end
 end

--- a/spec/requests/expense_pages_spec.rb
+++ b/spec/requests/expense_pages_spec.rb
@@ -10,7 +10,6 @@ describe "Expense pages", type: :request do
   describe "expense creation" do
     context "user is creating their first expense" do
       before do
-        visit root_path
         click_link "create a new expense"
       end
 

--- a/spec/requests/expense_pages_spec.rb
+++ b/spec/requests/expense_pages_spec.rb
@@ -48,4 +48,45 @@ describe "Expense pages", type: :request do
       it { expect(page).to have_selector(:link_or_button, 'Create expense') }
     end
   end
+
+  describe "expense updation" do
+    let!(:expense) { FactoryGirl.create(:expense, user: user) }
+
+    before do
+      visit root_path
+      click_link "Edit"
+    end
+
+    describe "with invalid information" do
+      describe "error messages" do
+        context "name is empty" do
+          before do
+            fill_in 'expense_name', with: ""
+            click_button "Update expense"
+          end
+
+          it { should have_content("The form contains 1 error.") }
+          it { should have_content("Name can\'t be blank") }
+        end
+      end
+    end
+
+    describe "with valid information" do
+        let(:new_expense_cost)  { 15 }
+        let(:new_expense_name)  { "Coffee" }
+        before do
+          fill_in 'expense_cost', with: new_expense_cost
+          fill_in 'expense_name', with: new_expense_name
+          click_button "Update expense"
+        end
+
+        it { should have_content("Expense updated") }
+        it "should update the expense with the correct cost" do
+          expect(expense.reload.cost).to  eq new_expense_cost
+        end
+        it "should update the expense with the correct name" do
+          expect(expense.reload.name).to  eq new_expense_name
+        end
+    end
+  end
 end

--- a/spec/requests/expense_pages_spec.rb
+++ b/spec/requests/expense_pages_spec.rb
@@ -29,7 +29,7 @@ describe "Expense pages", type: :request do
 
         before do
           fill_in "expense_name", with: "Sunglasses"
-          fill_in "expense_cost", with: "1000"
+          fill_in "expense_cost", with: 1000
           fill_in "expense_date", with: Time.zone.today
         end
         it "should create a expense" do

--- a/spec/requests/expense_pages_spec.rb
+++ b/spec/requests/expense_pages_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe "Expense pages", type: :request do
+
+  subject { page }
+
+  let(:user) { FactoryGirl.create(:user) }
+  before { log_in user }
+
+  describe "expense creation" do
+    context "user is creating their first expense" do
+      before do
+        visit root_path
+        click_link "create a new expense"
+      end
+
+      describe "with invalid information" do
+
+        it "should not create an expense" do
+          expect { click_button "Create expense" }.not_to change(Expense, :count)
+        end
+
+        describe "error messages" do
+          before { click_button "Create expense" }
+          it { should have_content('error') }
+        end
+      end
+
+      describe "with valid information" do
+
+        before do
+          fill_in 'expense_name', with: "Sunglasses"
+          fill_in 'expense_cost', with: "1000"
+          fill_in 'expense_date', with: Time.zone.today
+        end
+        it "should create a expense" do
+          expect { click_button "Create expense" }.to change(Expense, :count).by(1)
+        end
+      end
+    end
+
+    context "user has atleast one expense created" do
+      before do
+        FactoryGirl.create(:expense, user: user)
+        visit root_path
+        click_link "Create a new expense"
+      end
+
+      it { expect(page).to have_selector(:link_or_button, 'Create expense') }
+    end
+  end
+end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe "StaticPages", type: :request do
 
       expect(page).to have_content("Welcome to the Expenses App where tracking your expenses is made easy")
     end
+
+    describe "for signed-in users" do
+      let(:user) { FactoryGirl.create(:user) }
+      before do
+        FactoryGirl.create(:expense, user: user, name: "Shampoo")
+        FactoryGirl.create(:expense, user: user, name: "Toothpaste")
+        log_in user
+        visit root_path
+      end
+
+      it "should render the user expenses feed" do
+        user.expenses_feed.each do |expense|
+          expect(page).to have_content(expense.name)
+        end
+      end
+    end
   end
 
   describe "#about" do


### PR DESCRIPTION
Specs are added for -
1. Expense update
2. Content visible on user home page
3. Authorization specs around user expenses

Misc changes include -
1. Removal of unnecessary code
2. Separating parts of the specs based on the [Four Phase Test](https://robots.thoughtbot.com/four-phase-test) article. This is not yet rolled out in all specs. Rolling it out in all specs is a WIP
