### PR TITLE
Ensures that feature specs uses appropriate naming conventions wrt their specifications

### DIFF
--- a/spec/features/authentication_pages_spec.rb
+++ b/spec/features/authentication_pages_spec.rb
@@ -1,41 +1,41 @@
 require "rails_helper"
 
-describe "Authentication" do
+feature "Authentication" do
 
   subject { page }
 
-  describe "signin page" do
+  feature "signin page" do
     before { visit login_path }
 
-    it { should have_content('Log in') }
-    it { should have_title('Log in') }
+    scenario { should have_content('Log in') }
+    scenario { should have_title('Log in') }
   end
 
-  describe "signin" do
+  feature "signin" do
     before { visit login_path }
 
-    describe "with invalid information" do
+    feature "with invalid information" do
       before { click_button "Log in" }
 
-      it { should have_title('Log in') }
-      it { should have_selector('div.alert.alert-danger') }
+      scenario { should have_title('Log in') }
+      scenario { should have_selector('div.alert.alert-danger') }
 
-      describe "after visiting another page" do
+      feature "after visiting another page" do
         before { click_link "Home" }
-        it { should_not have_selector('div.alert.alert-danger') }
+        scenario { should_not have_selector('div.alert.alert-danger') }
       end
     end
 
-    describe "with valid information" do
+    feature "with valid information" do
       let(:user) { FactoryGirl.create(:user) }
       before do
         log_in user
       end
 
-      it { should have_content(user.name) }
-      it { should have_link('Profile',     href: user_path(user)) }
-      it { should have_link('Log out',    href: logout_path) }
-      it { should_not have_link('Log in', href: login_path) }
+      scenario { should have_content(user.name) }
+      scenario { should have_link('Profile',     href: user_path(user)) }
+      scenario { should have_link('Log out',    href: logout_path) }
+      scenario { should_not have_link('Log in', href: login_path) }
     end
   end
 end

--- a/spec/features/expense_pages_spec.rb
+++ b/spec/features/expense_pages_spec.rb
@@ -1,38 +1,38 @@
 require "rails_helper"
 
-describe "Expense pages", type: :feature do
+feature "Expense pages", type: :feature do
 
   subject { page }
 
   let(:user) { FactoryGirl.create(:user) }
   before { log_in user }
 
-  describe "expense creation" do
+  feature "expense creation" do
     context "user is creating their first expense" do
       before do
         click_link "create a new expense"
       end
 
-      describe "with invalid information" do
+      feature "with invalid information" do
 
-        it "should not create an expense" do
+        scenario "should not create an expense" do
           expect { click_button "Create expense" }.not_to change(Expense, :count)
         end
 
-        describe "error messages" do
+        feature "error messages" do
           before { click_button "Create expense" }
-          it { should have_content("error") }
+          scenario { should have_content("error") }
         end
       end
 
-      describe "with valid information" do
+      feature "with valid information" do
 
         before do
           fill_in "expense_name", with: "Sunglasses"
           fill_in "expense_cost", with: 1000
           fill_in "expense_date", with: Time.zone.today
         end
-        it "should create a expense" do
+        scenario "should create a expense" do
           expect { click_button "Create expense" }.to change(Expense, :count).by(1)
         end
       end
@@ -45,11 +45,11 @@ describe "Expense pages", type: :feature do
         click_link "Create a new expense"
       end
 
-      it { expect(page).to have_selector(:link_or_button, "Create expense") }
+      scenario { expect(page).to have_selector(:link_or_button, "Create expense") }
     end
   end
 
-  describe "expense updation" do
+  feature "expense updation" do
     let!(:expense) { FactoryGirl.create(:expense, user: user) }
 
     before do
@@ -57,21 +57,21 @@ describe "Expense pages", type: :feature do
       click_link "Edit"
     end
 
-    describe "with invalid information" do
-      describe "error messages" do
+    feature "with invalid information" do
+      feature "error messages" do
         context "name is empty" do
           before do
             fill_in "expense_name", with: ""
             click_button "Update expense"
           end
 
-          it { should have_content("The form contains 1 error.") }
-          it { should have_content("Name can\'t be blank") }
+          scenario { should have_content("The form contains 1 error.") }
+          scenario { should have_content("Name can\'t be blank") }
         end
       end
     end
 
-    describe "with valid information" do
+    feature "with valid information" do
       let(:new_expense_cost)  { 15 }
       let(:new_expense_name)  { "Coffee" }
       before do
@@ -80,36 +80,36 @@ describe "Expense pages", type: :feature do
         click_button "Update expense"
       end
 
-      it { should have_content("Expense updated") }
-      it "should update the expense with the correct cost" do
+      scenario { should have_content("Expense updated") }
+      scenario "should update the expense with the correct cost" do
         expect(expense.reload.cost).to eq new_expense_cost
       end
-      it "should update the expense with the correct name" do
+      scenario "should update the expense with the correct name" do
         expect(expense.reload.name).to eq new_expense_name
       end
     end
   end
 
-  describe "expense deletion" do
+  feature "expense deletion" do
     let!(:expense) { FactoryGirl.create(:expense, user: user) }
 
     before do
       visit root_path
     end
 
-    it "should decrease the total number of expense records by 1" do
+    scenario "should decrease the total number of expense records by 1" do
       expect { click_link "Delete" }.to change(Expense, :count).by(-1)
     end
 
-    it "should show the appropriate flash message on successful delete", js: true do
+    scenario "should show the appropriate flash message on successful delete", js: true do
       click_link "Delete"
 
       expect(page).to have_content("Expense deleted successfully")
     end
   end
 
-  describe "total expenses calculation" do
-    describe "with invalid information" do
+  feature "total expenses calculation" do
+    feature "with invalid information" do
       let!(:expense) { FactoryGirl.create(:expense, user: user) }
 
       before do
@@ -119,18 +119,18 @@ describe "Expense pages", type: :feature do
         click_button "Calculate total"
       end
 
-      it "should have the appropriate error related message", js: true do
+      scenario "should have the appropriate error related message", js: true do
         expect(page).to have_content("The form contains 1 error.")
       end
 
-      it "should show the appropriate error message", js: true do
+      scenario "should show the appropriate error message", js: true do
         expect(page).to have_content("From date can\'t be blank")
       end
     end
 
-    describe "with valid information" do
+    feature "with valid information" do
       context "there are incurred expenses with the specififed period" do
-        it "should calculate the total expenses accurately", js: true do
+        scenario "should calculate the total expenses accurately", js: true do
           FactoryGirl.create(:expense, user: user)
           FactoryGirl.create(:expense, user: user, name: "Petrol", cost: 68.50, date: Time.zone.yesterday)
           FactoryGirl.create(:expense, user: user, name: "Mug", cost: 50, date: Time.zone.tomorrow)
@@ -146,7 +146,7 @@ describe "Expense pages", type: :feature do
       end
 
       context "there are no expenses made within the specified period" do
-        it "should display an appropriate message about no expenses incurred", js: true do
+        scenario "should display an appropriate message about no expenses incurred", js: true do
           FactoryGirl.create(:expense, user: user, name: "Petrol", cost: 68.50, date: Time.zone.tomorrow)
 
           visit root_path

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
-RSpec.describe "HomePage", type: :feature do
-  describe "Home page" do
-    it "should have the name of the app" do
+RSpec.feature "HomePage", type: :feature do
+  feature "Home page" do
+    scenario "should have the name of the app" do
       visit root_path
       expect(page).to have_content("Expenses App")
     end
   end
 
-  describe "Sign up now! link" do
-    it "should go to the sign up page" do
+  feature "Sign up now! link" do
+    scenario "should go to the sign up page" do
       visit root_path
       click_link "Sign up now!"
       expect(page).to have_content("Sign up")
@@ -17,7 +17,7 @@ RSpec.describe "HomePage", type: :feature do
     end
   end
 
-  describe "login" do
+  feature "login" do
 
     before do
       visit login_path
@@ -25,23 +25,23 @@ RSpec.describe "HomePage", type: :feature do
     end
     let(:submit) { "Log in" }
 
-    describe "with valid information" do
+    feature "with valid information" do
       before do
         fill_in "Email",        with: @user.email
         fill_in "Password",     with: @user.password
       end
-      it "should login the user and display their email on the logged in page" do
+      scenario "should login the user and display their email on the logged in page" do
         click_button submit
         expect(page).to have_content("#{@user.name}")
       end
     end
 
-    describe "with invalid information" do
+    feature "with invalid information" do
       before do
         fill_in "Email",        with: @user.email
         fill_in "Password",     with: "a wrong password"
       end
-      it "should display appropriate login error message" do
+      scenario "should display appropriate login error message" do
         click_button submit
         expect(page).to have_content("Invalid email and/or password combination")
       end

--- a/spec/features/static_pages_spec.rb
+++ b/spec/features/static_pages_spec.rb
@@ -1,20 +1,20 @@
 require "rails_helper"
 
-RSpec.describe "StaticPages", type: :feature do
-  describe "#home" do
-    it "should have the title Home" do
+RSpec.feature "StaticPages", type: :feature do
+  feature "#home" do
+    scenario "should have the title Home" do
       visit root_path
 
       expect(page).to have_title("Expenses | Home")
     end
 
-    it "should have basic info about the app" do
+    scenario "should have basic info about the app" do
       visit root_path
 
       expect(page).to have_content("Welcome to the Expenses App where tracking your expenses is made easy")
     end
 
-    describe "for signed-in users" do
+    feature "for signed-in users" do
       let(:user) { FactoryGirl.create(:user) }
       before do
         FactoryGirl.create(:expense, user: user, name: "Shampoo")
@@ -23,7 +23,7 @@ RSpec.describe "StaticPages", type: :feature do
         visit root_path
       end
 
-      it "should render the user expenses feed" do
+      scenario "should render the user expenses feed" do
         user.expenses_feed.each do |expense|
           expect(page).to have_content(expense.name)
         end
@@ -31,56 +31,56 @@ RSpec.describe "StaticPages", type: :feature do
     end
   end
 
-  describe "#about" do
-    it "should have the title About" do
+  feature "#about" do
+    scenario "should have the title About" do
       visit about_path
 
       expect(page).to have_title("Expenses | About")
     end
 
-    it "should have the content 'About'" do
+    scenario "should have the content 'About'" do
       visit about_path
 
       expect(page).to have_content("About")
     end
   end
 
-  describe "#help" do
-    it "should have the title Help" do
+  feature "#help" do
+    scenario "should have the title Help" do
       visit help_path
 
       expect(page).to have_title("Expenses | Help")
     end
 
-    it "should have the content 'Help'" do
+    scenario "should have the content 'Help'" do
       visit help_path
 
       expect(page).to have_content("Help")
     end
   end
 
-  describe "#contact" do
-    it "should have the title Contact" do
+  feature "#contact" do
+    scenario "should have the title Contact" do
       visit contact_path
 
       expect(page).to have_title("Expenses | Contact")
     end
 
-    it "should have the content 'Contact'" do
+    scenario "should have the content 'Contact'" do
       visit contact_path
 
       expect(page).to have_content("Contact")
     end
   end
 
-  describe "#faq" do
-    it "should have the title FAQ" do
+  feature "#faq" do
+    scenario "should have the title FAQ" do
       visit faq_path
 
       expect(page).to have_title("Expenses | FAQ")
     end
 
-    it "should have the content 'FAQ'" do
+    scenario "should have the content 'FAQ'" do
       visit faq_path
 
       expect(page).to have_content("FAQ")

--- a/spec/features/user_pages_spec.rb
+++ b/spec/features/user_pages_spec.rb
@@ -1,25 +1,25 @@
 require "rails_helper"
 
-RSpec.describe "UserPages", type: :feature do
+RSpec.feature "UserPages", type: :feature do
 
-  describe "User pages" do
+  feature "User pages" do
 
     subject { page }
 
-    describe "signup page" do
+    feature "signup page" do
       before { visit signup_path }
 
       it { should have_content("Sign up") }
       it { should have_title("Expenses | Sign up") }
     end
 
-    describe "signup" do
+    feature "signup" do
 
       before { visit signup_path }
 
       let(:submit) { "Create my account" }
 
-      describe "with invalid information" do
+      feature "with invalid information" do
         before do
           fill_in "Email",        with: "user@example.com"
           fill_in "Password",     with: "foobar"
@@ -41,7 +41,7 @@ RSpec.describe "UserPages", type: :feature do
         end
       end
 
-      describe "with valid information" do
+      feature "with valid information" do
         before do
           fill_in "Email",        with: "user@example.com"
           fill_in "Name",         with: "John Doe"
@@ -68,7 +68,7 @@ RSpec.describe "UserPages", type: :feature do
           expect(page).to have_content("Log out")
         end
 
-        describe "after saving the user" do
+        feature "after saving the user" do
           before { click_button submit }
           let(:user) { User.find_by(email: 'user@example.com') }
 
@@ -79,7 +79,7 @@ RSpec.describe "UserPages", type: :feature do
       end
     end
 
-    describe "logout" do
+    feature "logout" do
       before do
         visit login_path
         @user = FactoryGirl.create(:user)
@@ -87,7 +87,7 @@ RSpec.describe "UserPages", type: :feature do
 
       let(:submit) { "Log in" }
 
-      describe "for a logged in user" do
+      feature "for a logged in user" do
         before do
           fill_in "Email",        with: @user.email
           fill_in "Password",     with: @user.password
@@ -101,26 +101,26 @@ RSpec.describe "UserPages", type: :feature do
       end
     end
 
-    describe "edit" do
+    feature "edit" do
       let(:user) { FactoryGirl.create(:user) }
       before do
         log_in user
         visit edit_user_path(user)
       end
 
-      describe "page" do
+      feature "page" do
         it { should have_content("Update your profile") }
         it { should have_title("Edit user") }
         it { should have_link('change', href: 'http://gravatar.com/emails') }
       end
 
-      describe "with invalid information" do
+      feature "with invalid information" do
         before { click_button "Save changes" }
 
         it { should have_content('error') }
       end
 
-      describe "with valid information" do
+      feature "with valid information" do
         let(:new_name)  { "New Name" }
         let(:new_email) { "new@example.com" }
         before do


### PR DESCRIPTION
In Feature specs, the “describe” block is replaced by “feature” and the
“it” block is replaced by “scenario”. This is the naming convention
generally followed when we use feature specs. Appropriate changes are
made here. These specs were originally request specs, appropriate
changes are incorporated once they’re moved within the features
directory.
