### PR TITLE
Ensures that a cost assigned to an empty string is an invalid expense record

### DIFF
--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -23,8 +23,15 @@ RSpec.describe Expense, type: :model do
   end
 
   describe "when expense cost is not present" do
-    before { @expense.cost = nil }
-    it { should_not be_valid }
+    context "expense cost is an empty string" do
+      before { @expense.cost = "" }
+      it { should_not be_valid }
+    end
+
+    context "expense cost is nil" do
+      before { @expense.cost = nil }
+      it { should_not be_valid }
+    end
   end
 
   describe "when expense name is not present" do


### PR DESCRIPTION
Appropriate changes are made to make the specs more descriptive around the check wrt cost not being present.
